### PR TITLE
Fix ESM loading of minecraft-data

### DIFF
--- a/Bot/BotActions.js
+++ b/Bot/BotActions.js
@@ -6,6 +6,9 @@
 
 import { Vec3 } from 'vec3';
 import { goals } from 'mineflayer-pathfinder';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
 
 // Custom Error Classes
 class ActionError extends Error {

--- a/LLM/ActionValidator.js
+++ b/LLM/ActionValidator.js
@@ -8,6 +8,9 @@ import Joi from 'joi';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
## Summary
- initialize `createRequire` in `ActionValidator` and `BotActions`
- use CommonJS `require` via `createRequire` to load `minecraft-data` in ESM

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68779d3ce76083289e3fa9560b77b3ec