### PR TITLE
Fix Node module imports for PiepsLama

### DIFF
--- a/Queues/EmergencyQueue.js
+++ b/Queues/EmergencyQueue.js
@@ -4,7 +4,8 @@
  * Minimale Latenz, maximale Autorität, temporäre Kontrolle.
  */
 
-import { createMachine, interpret } from 'mineflayer-statemachine';
+import statemachine from 'mineflayer-statemachine';
+const { createMachine, interpret } = statemachine;
 import winston from 'winston';
 import ErrorRecovery from '../Utils/ErrorRecovery.js';
 

--- a/Queues/RespawnQueue.js
+++ b/Queues/RespawnQueue.js
@@ -4,7 +4,8 @@
  * Entscheidet rational zwischen Item-Recovery, Base-Return oder Fresh-Start.
  */
 
-import { createMachine, interpret } from 'mineflayer-statemachine';
+import statemachine from 'mineflayer-statemachine';
+const { createMachine, interpret } = statemachine;
 import winston from 'winston';
 import ErrorRecovery from '../Utils/ErrorRecovery.js';
 import { Vec3 } from 'vec3';

--- a/Queues/StandardQueue.js
+++ b/Queues/StandardQueue.js
@@ -4,7 +4,8 @@
  * Implementiert die Dreifaltigkeit: Ziel → Handlung → Aktion
  */
 
-import { createMachine, interpret, State } from 'mineflayer-statemachine';
+import statemachine from 'mineflayer-statemachine';
+const { createMachine, interpret, State } = statemachine;
 import winston from 'winston';
 import ErrorRecovery from '../Utils/ErrorRecovery.js';
 

--- a/bot.js
+++ b/bot.js
@@ -12,9 +12,10 @@ import mineflayer from 'mineflayer';
 import { pathfinder } from 'mineflayer-pathfinder';
 import { plugin as collectBlock } from 'mineflayer-collectblock';
 import { plugin as pvp } from 'mineflayer-pvp';
-import { plugin as armorManager } from 'mineflayer-armor-manager';
-import { plugin as autoEat } from 'mineflayer-auto-eat';
-import { Transitions, BotStateMachine, NestedStateMachine } from 'mineflayer-statemachine';
+import armorManager from 'mineflayer-armor-manager';
+import autoEat from 'mineflayer-auto-eat';
+import statemachine from 'mineflayer-statemachine';
+const { BotStateMachine, NestedStateMachine } = statemachine;
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mineflayer": "^4.30.0",
     "mineflayer-pathfinder": "^2.4.5",
     "mineflayer-collectblock": "^1.6.0",
-    "mineflayer-statemachine": "^1.11.0",
+    "mineflayer-statemachine": "^1.7.0",
     "mineflayer-armor-manager": "^2.0.1",
     "mineflayer-auto-eat": "^2.3.3",
     "mineflayer-pvp": "^1.3.2",


### PR DESCRIPTION
## Summary
- point mineflayer-statemachine to latest available version
- import statemachine module via default export
- import armor-manager and auto-eat via default export
- adjust queue imports for createMachine/interpret

## Testing
- `npm install`
- `npm start` *(fails to connect to Minecraft server but starts the bot)*

------
https://chatgpt.com/codex/tasks/task_e_6877a3a5c9388328b15e023fbe170a6b